### PR TITLE
orangebomb用のトラッキングタグを追加

### DIFF
--- a/themes/orangebomb/layouts/partials/analytics.html
+++ b/themes/orangebomb/layouts/partials/analytics.html
@@ -3,9 +3,9 @@
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '{{ . }}', 'auto');
+  ga('create', 'UA-83267965-1', 'auto');
   ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
- `themes/orangebomb/layouts/partials/analytics.html`

の内容を `blog.orangebomb.org/` 用の内容へ差し替える。