### PR TITLE
analytics.html内の不要なコードをカット

### DIFF
--- a/themes/orangebomb/layouts/partials/analytics.html
+++ b/themes/orangebomb/layouts/partials/analytics.html
@@ -1,4 +1,3 @@
-{{ with .Site.Params.Analytics }}
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -9,4 +8,3 @@
   ga('send', 'pageview');
 
 </script>
-{{ end }}


### PR DESCRIPTION
```
{{ with .Site.Params.Analytics }}
{{ end }}
```

このコードがあるせいでトラッキングタグが出力されなかった。カットする。