### PR TITLE
フォント指定から「りょうゴシック PlusN」を外し、Adobe Typekitのコードを削除 / グリッド調整 / その他微調整

### DIFF
--- a/themes/orangebomb/layouts/partials/footer.html
+++ b/themes/orangebomb/layouts/partials/footer.html
@@ -21,5 +21,3 @@
 </footer>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-<script src="https://use.typekit.net/abu0cda.js"></script>
-<script>try{Typekit.load({ async: true });}catch(e){}</script>

--- a/themes/orangebomb/static/css/base.css
+++ b/themes/orangebomb/static/css/base.css
@@ -1,10 +1,10 @@
 body {
-  color: #292929;
+  color: #333;
   padding: 0;
   margin: 0;
   font-family: 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic ProN', Meiryo, 'MS PGothic', Arial, sans-serif;
-  font-size: 16px;
-  line-height: 190%;
+  font-size: 15px;
+  line-height: 180%;
   background-color: #f8f9fb;
 }
 

--- a/themes/orangebomb/static/css/base.css
+++ b/themes/orangebomb/static/css/base.css
@@ -2,7 +2,7 @@ body {
   color: #292929;
   padding: 0;
   margin: 0;
-  font-family: "ryo-gothic-plusn", 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic ProN', Meiryo, 'MS PGothic', Arial, sans-serif;
+  font-family: 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic ProN', Meiryo, 'MS PGothic', Arial, sans-serif;
   font-size: 16px;
   line-height: 190%;
   background-color: #f8f9fb;

--- a/themes/orangebomb/static/css/contents.css
+++ b/themes/orangebomb/static/css/contents.css
@@ -13,15 +13,15 @@ h2 {
 }
 
 h3 {
-  font-size: 1.2em;
-}
-
-h4 {
   font-size: 1em;
 }
 
-h5 {
+h4 {
   font-size: .8em;
+}
+
+h5 {
+  font-size: .6em;
 }
 
 /* container */

--- a/themes/orangebomb/static/css/footer.css
+++ b/themes/orangebomb/static/css/footer.css
@@ -4,7 +4,7 @@
   max-width: 590px;
   font-size: 12px;
   margin: 50px auto 100px;
-  padding: 0 15px;
+  padding: 0 26px;
 }
 
 @media screen and (max-width: 550px) {

--- a/themes/orangebomb/static/css/header.css
+++ b/themes/orangebomb/static/css/header.css
@@ -2,7 +2,7 @@
 
 .header {
   background-color: #fff;
-  padding: 30px 16px;
+  padding: 30px 0;
 }
 
 .header:after {
@@ -13,15 +13,10 @@
 
 .header-inner {
   max-width: 590px;
+  padding: 0 26px;
   margin: 0 auto;
+  height: 25px;
 }
-
-@media screen and (max-width: 550px) {
-  .header-inner {
-    padding: 0 15px;
-  }
-}
-
 
 .header h1 {
   margin: 0;
@@ -47,16 +42,11 @@
   font-family: 'Karla', sans-serif;
   padding: 0;
   font-size: 13px;
-  width: 510px;
+  width: 220px;
   height: 25px;
-  line-height: 28px;
-  float: right;
-}
-
-@media screen and (max-width: 550px) {
-  .menu {
-    width: 260px;
-  }
+  line-height: 25px;
+  float: left;
+  margin-left: 50px;
 }
 
 .menu > li {


### PR DESCRIPTION
> フォント指定から「りょうゴシック PlusN」を外し、Adobe Typekitのコードを削除

しばらく運用して、 `りょうゴシック PlusN` では読みにくいという判定をした。
また、 `Adobe Typekit` を外すことで読み込み速度も上がると思われる。

- https://github.com/keitakawamoto/orangebomb.org/pull/9#issuecomment-206416553
- https://github.com/keitakawamoto/orangebomb.org/pull/9/commits/c016eccf4f3ce10db07be598d4c6c56f6f92ae6c

上記で追加した `Adobe Typekit` を削除する。

 > グリッド調整 / その他微調整

横幅を可変させた際に、ヘッダ・コンテンツ部分・フッタの縦軸が揃っていない部分があったので揃えた。
前述の `Adobe Typekit` カットによりヒラギノに変えたので、フォント周りのスタイリングの調整をした。