### PR TITLE
iconにaria-hidden true追加・sr-onlyによる代替テキストを挿入

### DIFF
--- a/themes/orangebomb/layouts/partials/content.html
+++ b/themes/orangebomb/layouts/partials/content.html
@@ -7,7 +7,8 @@
           <time>{{ .Date.Format "2006-01-02" }}</time>
         </div>
         <div class="tags">
-          <i class="fa fa-tags tag-icon"></i>
+          <i class="fa fa-tags tag-icon" aria-hidden="true"></i>
+          <span class="sr-only">Tags</span>
           <ul>
           {{ range .Params.tags }}
             <li><a class="tag-link" href="/tags/{{ . | urlize }}">{{ . }}</a></li>

--- a/themes/orangebomb/layouts/partials/footer.html
+++ b/themes/orangebomb/layouts/partials/footer.html
@@ -7,13 +7,48 @@
     {{ end }}
   </div>
   <ul class="social">
-    <li><a href="https://twitter.com/{{ .Site.Params.Twitter }}" target="_blank" class="twitter"><i class="fa fa-twitter"></i></a></li>
-    <li><a href="https://dribbble.com/{{ .Site.Params.Dribbble }}" target="_blank" class="dribbble"><i class="fa fa-dribbble"></i></a></li>
-    <li><a href="https://github.com/{{ .Site.Params.GitHub }}" target="_blank" class="github"><i class="fa fa-github"></i></a></li>
-    <li><a href="https://jp.pinterest.com/{{ .Site.Params.Pintelest }}" target="_blank" class="pinterest"><i class="fa fa-pinterest"></i></a></li>
-    <li><a href="http://codepen.io/{{ .Site.Params.CodePen }}" target="_blank" class="codepen"><i class="fa fa-codepen"></i></a></li>
-    <li><a href="https://www.instagram.com/{{ .Site.Params.Instagram }}" target="_blank" class="instagram"><i class="fa fa-instagram"></i></a></li>
-    <li><a href="/index.xml" target="_blank" class="rss"><i class="fa fa-rss"></i></a></li>
+    <li>
+      <a href="https://twitter.com/{{ .Site.Params.Twitter }}" target="_blank" class="twitter">
+        <i class="fa fa-twitter" aria-hidden="true"></i>
+        <span class="sr-only">Twitter</span>
+      </a>
+    </li>
+    <li>
+      <a href="https://dribbble.com/{{ .Site.Params.Dribbble }}" target="_blank" class="dribbble">
+        <i class="fa fa-dribbble" aria-hidden="true"></i>
+        <span class="sr-only">Dribbble</span>
+      </a>
+    </li>
+    <li>
+      <a href="https://github.com/{{ .Site.Params.GitHub }}" target="_blank" class="github">
+        <i class="fa fa-github" aria-hidden="true"></i>
+        <span class="sr-only">GitHub</span>
+      </a>
+    </li>
+    <li>
+      <a href="https://jp.pinterest.com/{{ .Site.Params.Pintelest }}" target="_blank" class="pinterest">
+        <i class="fa fa-pinterest" aria-hidden="true"></i>
+        <span class="sr-only">Pinterest</span>
+      </a>
+    </li>
+    <li>
+      <a href="http://codepen.io/{{ .Site.Params.CodePen }}" target="_blank" class="codepen">
+        <i class="fa fa-codepen" aria-hidden="true"></i>
+        <span class="sr-only">Codepen</span>
+      </a>
+    </li>
+    <li>
+      <a href="https://www.instagram.com/{{ .Site.Params.Instagram }}" target="_blank" class="instagram">
+        <i class="fa fa-instagram" aria-hidden="true"></i>
+        <span class="sr-only">Instagram</span>
+      </a>
+    </li>
+    <li>
+      <a href="/index.xml" target="_blank" class="rss">
+        <i class="fa fa-rss" aria-hidden="true"></i>
+        <span class="sr-only">RSS</span>
+      </a>
+    </li>
   </ul>
   <p class="copyright">
     <small><span class="copy-c">&copy;</span> {{ .Site.Author.Name }} Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>


### PR DESCRIPTION
スクリーンリーダーでアイコンが「読み上げ不能」となる問題を解決する。
スクリーンリーダーはMac VoiceOver、テストブラウザはChrome。

## 参考

- [Font-Awesomeでアクセシビリティを確保しながらウェブフォントを活用する - Qiita](http://qiita.com/beijaflor/items/88395c52804a06dbaccc)
- [Font Awesome & Accessibility](http://fontawesome.io/accessibility/)

> 意味を持つアイコン
> アイコンそのものに意味をもたせて、削除するとビジュアルデザイン上でも意味をなさない場合には`<span class="sr-only">{label}</span>` を利用して、代替テキストをスクリーンリーダーに認識させます。

これを利用する。

アイコンそのものには `aria-hidden="true"` を追加。これでアイコンは目に見えるが、読み上げられない存在となる。その代わりに読み上げは `<span class="sr-only">{label}</span>` の部分を読み上げられるようになる。

## evidence

![7 -03-2017 03-45-02](https://user-images.githubusercontent.com/1661325/27772760-be076246-5fa3-11e7-81ef-06bcfb9427a8.gif)
![7 -03-2017 03-44-39](https://user-images.githubusercontent.com/1661325/27772763-c0e4a4c4-5fa3-11e7-881f-6632fff76759.gif)

（ `@keita_kawamoto` と自己紹介部分、開発環境では表示されない..）