### PR TITLE
はてブのソーシャルボタンを純正に戻す

### DIFF
--- a/themes/orangebomb/layouts/partials/social.html
+++ b/themes/orangebomb/layouts/partials/social.html
@@ -1,6 +1,6 @@
 <div class="social-btn">
   <div>
-    <a href="http://b.hatena.ne.jp/entry/blog.orangebomb.org{{ .RelPermalink }}" class="hatena-bookmark-button" data-hatena-bookmark-title="{{ .Title }}・{{ .Site.Title }}" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+    <a href="http://b.hatena.ne.jp/entry/" class="hatena-bookmark-button" data-hatena-bookmark-layout="basic-label-counter" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
   </div>
   <div>
     <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>


### PR DESCRIPTION
ref https://github.com/keitakawamoto/orangebomb.org/issues/134

URLの末尾がタイトルになる等の状態でシェアされる等の不具合が発生している。
原因は純正をカスタマイズしたものを実装してしまっているための模様。
配布されているURLをそのまま配置し解決を狙う。