### PR TITLE
SSL対応で省略してはいけない部分までプロトコル省略していたので、httpsと明記する

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 My blog theme for Hugo. 
 
-- [Orangebomb](//blog.orangebomb.org)
+- [Orangebomb](https://blog.orangebomb.org)

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 title        = "Orangebomb"
-baseurl      = "//blog.orangebomb.org"
+baseurl      = "https://blog.orangebomb.org"
 languageCode = "ja-jp"
 
 [author]

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Disallow:
-Sitemap: //blog.orangebomb.org/sitemap.xml
+Sitemap: https://blog.orangebomb.org/sitemap.xml


### PR DESCRIPTION
SSL対応で省略してはいけない部分までプロトコル省略したのが原因で問題が起こっている。httpsと明示し解決する。

```
june29 [21 minutes ago] 
@kawamoto フィードの中で link が壊れているっぽいですね〜 Hugo殿〜
https://blog.orangebomb.org/index.xml


kawamoto [19 minutes ago] 
えええ…


kawamoto [18 minutes ago] 
https://git.pepabo.com/storage/user/72/files/1832ab88-6d5d-11e7-8f8f-3e6da3f16c3e ここですね


june29 [17 minutes ago] 
ですです


kawamoto [17 minutes ago] 
たしかssl対策をしたときに消したような


kawamoto [17 minutes ago] 
消したらいけないところだったんだ


kawamoto [16 minutes ago] 
https://github.com/keitakawamoto/orangebomb.org/pull/123/commits/86329afa0aac0e46de0f9a005a6277289eca0e8e (edited)

kawamoto [15 minutes ago] 
画像以外は省略ではなく httpsと明記しますね


june29 [15 minutes ago] 
ははーん なるほど！


june29 [14 minutes ago] 
よさそうな気がします :ok_hand:


kawamoto [14 minutes ago] 
はてブボタンが狂ったのも、これが関係しているのかも… https://github.com/keitakawamoto/orangebomb.org/issues/134 (edited)


june29 [14 minutes ago] 
わー ありそう


kawamoto [14 minutes ago] 
改修します！ありがとうございますー！


kawamoto [13 minutes ago] 
よかった、絶対自分では気づけなかった


june29 [13 minutes ago] 
ぼくが最近 Hugo で構築したサイトは、ぜんぶ https にしたので (いま新規につくるならそうしますよね) 設定も https 直書きで上手くいっています！参考になるかわかりませんが〜
```