### PR TITLE
記事内の画像にborder-radiusを設定する

### DIFF
--- a/themes/orangebomb/static/css/contents.css
+++ b/themes/orangebomb/static/css/contents.css
@@ -36,6 +36,7 @@ h5 {
   max-width: 100%;
   margin: 40px auto;
   display: block;
+  border-radius: 5px;
 }
 
 @media screen and (max-width: 550px) {


### PR DESCRIPTION
Twitterの埋め込みが `border-radius: 5px;` だったので、画像についても同じ値の `border-radius` を設定する。
このブログでは、画像には丸みがあった方が、好み。


![image](https://user-images.githubusercontent.com/1661325/28459536-d91f950e-6e48-11e7-948d-eb12341d453e.png)
![image](https://user-images.githubusercontent.com/1661325/28459546-df368290-6e48-11e7-88ed-6ae4f466bfe0.png)


### シャドウ付きには無関係

![image](https://user-images.githubusercontent.com/1661325/28459561-ee717f4e-6e48-11e7-8aea-e0af1ee90242.png)
