### PR TITLE
ogimageの条件分岐を、タイトルと同じ条件分岐に変更する

### DIFF
--- a/themes/orangebomb/layouts/partials/head.html
+++ b/themes/orangebomb/layouts/partials/head.html
@@ -20,13 +20,13 @@
   <meta property="og:url" content="{{ .Permalink }}">
   <meta property="og:description" content="{{ if .IsPage }}{{ .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}">
   <!-- og images -->
-  {{ if .IsHome }}
+  {{ if eq .URL "/" }}
     <meta property="og:image" content="//blog.orangebomb.org/images/ogp.png">
     <meta name="twitter:image" content="//blog.orangebomb.org/images/ogp.png">
-  {{ else if .IsPage }}
+  {{ else }}
     <meta property="og:image" content="{{ .Site.BaseURL }}{{ .Params.eyecatch }}">
     <meta name="twitter:image" content="{{ .Site.BaseURL }}{{ .Params.eyecatch }}">
-  {{end}}
+  {{ end }}
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <link rel="stylesheet" href="/css/base.css">
   <link rel="stylesheet" href="/css/header.css">


### PR DESCRIPTION
https://github.com/keitakawamoto/orangebomb.org/pull/143

> https://github.com/keitakawamoto/orangebomb.org/pull/140#issuecomment-317610255 で行なったDescriptionとogimageの分岐が間違っておりhead内が狂ってしまった（ローカルではうまく行ったのに、デプロイしたらダメだった）

結局 `IsHome` を使った部分はダメだった。重要なのは

- homeなのか？
- それ以外なのか？

である。 `IsHome`  にこだわらず考えたら、既にそうしている箇所があることに気づいた。

```
  {{ if eq .URL "/" }}
    <title>{{ .Site.Title }}</title>
  {{ else }}
    <title>{{ .Title }} &nbsp;-&nbsp; {{ .Site.Title }}</title>
  {{ end }}
```

この分岐を試す。