### PR TITLE
反転させた時の色指定を復活

### DIFF
--- a/themes/orangebomb/static/css/base.css
+++ b/themes/orangebomb/static/css/base.css
@@ -70,6 +70,13 @@ hr {
   border-bottom: 1px solid #f0f0f0;
 }
 
+/* selection */
+
+::selection {
+  background: #fa7033;
+  color: #fff;
+}
+
 /* link */
 
 a {


### PR DESCRIPTION
[ブログテンプレートを作った時](https://github.com/keitakawamoto/orangebomb.org/pull/9#issuecomment-241278541) に、反転させたらオレンジの色がつくようにカスタマイズした。

![image](https://user-images.githubusercontent.com/1661325/41190995-5576c3ec-6c23-11e8-997a-fd34287d8d49.png)

しかし、スマホビューの調整の中で誤って削除してしまっていた。

https://github.com/keitakawamoto/orangebomb.org/commit/acf1e055f64897387380420dbcf52258d990c05a#diff-927b98ad2e76a47a73cf8cc2aa5c8371L11

そのため復活させる。

## 関連commit

- [::selection擬似要素を使って反転時の色を変更](https://github.com/keitakawamoto/orangebomb.org/commit/5bd06fdfeeb041bd945fa5c76f809e036edce141)
- [反転した時のオレンジをまぶしくない程度に鮮やかにした](https://github.com/keitakawamoto/orangebomb.org/commit/7f42dbeaa3a20b7d3f6aebc9b650fbb3e82ef0c9#diff-927b98ad2e76a47a73cf8cc2aa5c8371)

## 今回の調整点

（1）firefox用のベンダープレフィックスはfirefox62以降必要なくなっていたのでカット。

https://caniuse.com/#search=%3A%3Aselection

![image](https://user-images.githubusercontent.com/1661325/41191025-e524f888-6c23-11e8-8c4a-081092979e70.png)

（２）今回も少し色調整をした
（３）役割を明示したコメントアウトを追加した

## evidence

![image](https://user-images.githubusercontent.com/1661325/41191035-06f5b6b4-6c24-11e8-854a-534d195bbf9d.png)
