### PR TITLE
og:image部分でURLを直書きしていた部分を .Site.BaseURL に置き換える

### DIFF
--- a/themes/orangebomb/layouts/partials/head.html
+++ b/themes/orangebomb/layouts/partials/head.html
@@ -21,8 +21,8 @@
   <meta property="og:description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.description }}{{ end }}">
   <!-- og images -->
   {{ if eq .URL "/" }}
-    <meta property="og:image" content="//blog.orangebomb.org/images/ogp.png">
-    <meta name="twitter:image" content="//blog.orangebomb.org/images/ogp.png">
+    <meta property="og:image" content="{{ .Site.BaseURL }}/images/ogp.png">
+    <meta name="twitter:image" content="{{ .Site.BaseURL }}/images/ogp.png">
   {{ else }}
     <meta property="og:image" content="{{ .Site.BaseURL }}{{ .Params.eyecatch }}">
     <meta name="twitter:image" content="{{ .Site.BaseURL }}{{ .Params.eyecatch }}">


### PR DESCRIPTION
https://github.com/keitakawamoto/orangebomb.org/issues/170 で書いている通り、Twitterカードがうまく表示されない。原因はトップページのOGPの指定方法と思われる。
個別記事の方はうまくいっているので、指定方法を同じ `{{ .Site.BaseURL }}` に合わせる。

```diff
-<meta property="og:image" content="//blog.orangebomb.org/images/ogp.png">
+<meta property="og:image" content="{{ .Site.BaseURL }}/images/ogp.png">
```
